### PR TITLE
Drawer animation change from react-native-side-menu to react-native-s…

### DIFF
--- a/app/LoadedApp.tsx
+++ b/app/LoadedApp.tsx
@@ -6,7 +6,7 @@ import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome';
 import {faList, faUpload, faDownload, faCog} from '@fortawesome/free-solid-svg-icons';
 
-import SideMenu from 'react-native-side-menu';
+import SideMenu from 'react-native-side-menu-updated';
 import RPC from './rpc';
 import AppState, {
   TotalBalance,

--- a/components/SendScreen.tsx
+++ b/components/SendScreen.tsx
@@ -233,10 +233,10 @@ const SendScreen: React.FunctionComponent<SendScreenProps> = ({
 
   useEffect(() => {
     const keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', () => {
-      Animated.timing(slideAnim, {toValue: 0 - titleViewHeight + 25, duration: 100, easing: EasingNode.linear}).start();
+      Animated.timing(slideAnim, {toValue: 0 - titleViewHeight + 25, duration: 100, easing: EasingNode.linear, useNativeDriver: true}).start();
     });
     const keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', () => {
-      Animated.timing(slideAnim, {toValue: 0, duration: 100, easing: EasingNode.linear}).start();
+      Animated.timing(slideAnim, {toValue: 0, duration: 100, easing: EasingNode.linear, useNativeDriver: true}).start();
     });
 
     return () => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-native-reanimated": "^2.1.0",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.2.0",
-    "react-native-side-menu": "^1.1.3",
+    "react-native-side-menu-updated": "^1.3.2",
     "react-native-simple-toast": "^1.1.3",
     "react-native-svg": "^12.1.1",
     "react-native-tab-view": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5856,10 +5856,10 @@ react-native-screens@^3.2.0:
   dependencies:
     warn-once "^0.1.0"
 
-react-native-side-menu@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-side-menu/-/react-native-side-menu-1.1.3.tgz#6ef5d2232ecf718312df6cedef019148bac3073a"
-  integrity sha1-bvXSIy7PcYMS32zt7wGRSLrDBzo=
+react-native-side-menu-updated@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-side-menu-updated/-/react-native-side-menu-updated-1.3.2.tgz#81a31e526228e35f4b644ed64f9b85f4cf838b76"
+  integrity sha512-38MErOgwoUQdFY4IEIYAO+JokWk3hCOhqirqwWBBXqwgTD9qeezlv9eWEMBaDsQSk/iW+cqLPkAafOAWeSXCVw==
   dependencies:
     prop-types "^15.5.10"
 


### PR DESCRIPTION
The react-native-side-menu is obsolete, and I changed for a new version of the same library called: react-native-side-menu-updated.

Screen shots:

![Screenshot_20220507_164141](https://user-images.githubusercontent.com/43755989/167274324-303a2577-b2ce-4a8f-b530-a8aa45b01936.png)
![Screenshot_20220507_164152](https://user-images.githubusercontent.com/43755989/167274329-0dc9c00e-924c-4de0-af5e-b8e3a9d28522.png)