### PR TITLE
Removed the send all button from the send screen

### DIFF
--- a/components/SendScreen.tsx
+++ b/components/SendScreen.tsx
@@ -573,11 +573,6 @@ const SendScreen: React.FunctionComponent<SendScreenProps> = ({
               <View style={{display: 'flex', flexDirection: 'column'}}>
                 <View style={{display: 'flex', flexDirection: 'row', marginTop: 10}}>
                   <FadeText>Spendable: ᙇ {Utils.maxPrecisionTrimmed(getMaxAmount())} </FadeText>
-                  {/* <ClickableText
-                    style={{marginLeft: 5, marginTop: Platform.OS === 'ios' ? 2 : 0}}
-                    onPress={() => setMaxAmount(i)}>
-                    Send All
-                  </ClickableText> */}
                 </View>
                 {stillConfirming && (
                   <View

--- a/components/SendScreen.tsx
+++ b/components/SendScreen.tsx
@@ -573,11 +573,11 @@ const SendScreen: React.FunctionComponent<SendScreenProps> = ({
               <View style={{display: 'flex', flexDirection: 'column'}}>
                 <View style={{display: 'flex', flexDirection: 'row', marginTop: 10}}>
                   <FadeText>Spendable: ᙇ {Utils.maxPrecisionTrimmed(getMaxAmount())} </FadeText>
-                  <ClickableText
+                  {/* <ClickableText
                     style={{marginLeft: 5, marginTop: Platform.OS === 'ios' ? 2 : 0}}
                     onPress={() => setMaxAmount(i)}>
                     Send All
-                  </ClickableText>
+                  </ClickableText> */}
                 </View>
                 {stillConfirming && (
                   <View


### PR DESCRIPTION
The best idea is to remove the 'send all' button, It's not very useful and very dangerous. Thank you @Gunnar-Stunnar for doing that.